### PR TITLE
Indicate Linux only support for libfuzzer-sys.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@ Barebones wrapper around libFuzzer runtime library.
 
 The CPP parts are extracted from llvm git repository with `git filter-branch`.
 
+libFuzzer relies on LLVM sanitizer support. The Rust compiler has built-in support for LLVM sanitizer support, for now, it's limited to Linux. As a result, libfuzzer-sys only works on Linux.
+
 # How to use
 
 “Manual” usage of this library looks like this:


### PR DESCRIPTION
Fixes https://github.com/rust-fuzz/libfuzzer-sys/issues/1.