### PR TITLE
Support for arbitrary data types

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,5 +12,8 @@ notifications:
   email: false
 script:
   - cd example
-  - cargo rustc -- -C passes='sancov' -C llvm-args='-sanitizer-coverage-level=3' -Z sanitizer=address
-  - (! ./target/debug/example)
+  - cargo rustc --release -- -C passes='sancov' -C llvm-args='-sanitizer-coverage-level=4' -Z sanitizer=address
+  - (! ./target/release/example -runs=100000)
+  - cd ../example_arbitrary
+  - cargo rustc --release -- -C passes='sancov' -C llvm-args='-sanitizer-coverage-level=4' -Z sanitizer=address
+  - (! ./target/release/example -runs=10000000)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ license = "MIT/Apache-2.0/NCSA"
 members = ["."]
 
 [dependencies]
+arbitrary = "0.1"
 
 [build-dependencies]
 gcc = "0.3"

--- a/example_arbitrary/Cargo.toml
+++ b/example_arbitrary/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "example"
+version = "0.1.0"
+authors = ["Simonas Kazlauskas <git@kazlauskas.me>"]
+
+[workspace]
+members = ["."]
+
+[dependencies]
+libfuzzer-sys = { path = ".." }
+arbitrary = "0.1"

--- a/example_arbitrary/src/main.rs
+++ b/example_arbitrary/src/main.rs
@@ -3,8 +3,8 @@
 #[macro_use]
 extern crate libfuzzer_sys;
 
-fuzz_target!(|data: &[u8]| {
-    if data == b"banana!" {
+fuzz_target!(|data: u16| {
+    if data == 0xba7 { // ba[nana]
         panic!("success!");
     }
 });


### PR DESCRIPTION
Not efficient[1], but that mostly needs work on the arbitrary crate, as
opposed to work on libfuzzer-sys.

[1]: fuzzing struggles with e.g.

    fuzz_target!(|data: String| { if data == "banana" { panic!() } });

and takes quite a while to find an input that fails the check (compared
to fuzzing against raw bytes). It seems to me that to take full
advantage of fuzzing structured data, one would have to adjust libFuzzer
somehow or, perhaps, rewrite libFuzzer in rust having precisely
structured fuzzing in mind.