### PR TITLE
Optionally use a custom libFuzzer.a archive

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,17 +1,30 @@
 extern crate gcc;
 
 fn main() {
-    let sources = ::std::fs::read_dir("llvm/lib/Fuzzer")
-        .expect("listable source directory")
-        .map(|de| de.expect("file in directory").path())
-        .filter(|p| p.extension().map(|ext| ext == "cpp") == Some(true))
-        .collect::<Vec<_>>();
-    let mut config = gcc::Config::new();
-    for source in sources.iter() {
-        config.file(source.to_str().unwrap());
+    if let Ok(custom) = ::std::env::var("CUSTOM_LIBFUZZER_PATH") {
+        let custom_lib_dir = ::std::path::PathBuf::from(&custom);
+        let custom_lib_dir = custom_lib_dir.parent().unwrap().to_string_lossy();
+
+        let custom_lib_name = ::std::path::PathBuf::from(&custom);
+        let custom_lib_name = custom_lib_name.file_stem().unwrap().to_string_lossy();
+        let custom_lib_name = &custom_lib_name[3..];
+
+        println!("cargo:rustc-link-search=native={}", custom_lib_dir);
+        println!("cargo:rustc-link-lib=static={}", custom_lib_name);
+        println!("cargo:rustc-link-lib=stdc++");
+    } else {
+        let mut config = gcc::Config::new();
+        let sources = ::std::fs::read_dir("llvm/lib/Fuzzer")
+            .expect("listable source directory")
+            .map(|de| de.expect("file in directory").path())
+            .filter(|p| p.extension().map(|ext| ext == "cpp") == Some(true))
+            .collect::<Vec<_>>();
+        for source in sources.iter() {
+            config.file(source.to_str().unwrap());
+        }
+        config.flag("-std=c++11");
+        config.flag("-fno-omit-frame-pointer");
+        config.cpp(true);
+        config.compile("libfuzzer.a");
     }
-    config.flag("-std=c++11");
-    config.flag("-fno-omit-frame-pointer");
-    config.cpp(true);
-    config.compile("libfuzzer.a");
 }

--- a/build.rs
+++ b/build.rs
@@ -2,15 +2,15 @@ extern crate gcc;
 
 fn main() {
     if let Ok(custom) = ::std::env::var("CUSTOM_LIBFUZZER_PATH") {
-        let custom_lib_dir = ::std::path::PathBuf::from(&custom);
-        let custom_lib_dir = custom_lib_dir.parent().unwrap().to_string_lossy();
+        let custom_lib_path = ::std::path::PathBuf::from(&custom);
+        let custom_lib_dir = custom_lib_path.parent().unwrap().to_string_lossy();
 
-        let custom_lib_name = ::std::path::PathBuf::from(&custom);
-        let custom_lib_name = custom_lib_name.file_stem().unwrap().to_string_lossy();
-        let custom_lib_name = &custom_lib_name[3..];
+        let custom_lib_name = custom_lib_path.file_stem().unwrap().to_string_lossy();
+        let custom_lib_name = custom_lib_name.trim_left_matches("lib");
 
         println!("cargo:rustc-link-search=native={}", custom_lib_dir);
         println!("cargo:rustc-link-lib=static={}", custom_lib_name);
+        /* FIXME: this is assuming a C++ fuzzer, but should be customizable */
         println!("cargo:rustc-link-lib=stdc++");
     } else {
         let mut config = gcc::Config::new();


### PR DESCRIPTION
Tweak build.rs so that it's possible to use a custom libFuzzer.a
archive. This is necessary when using OSS-Fuzz
(https://github.com/google/oss-fuzz): the build
system has to link with the libFuzzer provided by
the `LIB_FUZZING_ENGINE` environment variable (see
https://github.com/google/oss-fuzz/blob/master/docs/new_project_guide.md)