### PR TITLE
Fix `fuzz_target!` with `Arbitrary`-implementing types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 authors = ["The cargo-fuzz Project Developers"]
 repository = "https://github.com/rust-fuzz/libfuzzer-sys"
 license = "MIT/Apache-2.0/NCSA"
+edition = "2018"
 
 # cargo-fuzz puts this in a crate subdirectory,
 # which causes problems if the crate uses workspaces.

--- a/README.md
+++ b/README.md
@@ -32,9 +32,7 @@ and change the `src/main.rs` to fuzz your code:
 ```rust
 #![no_main]
 
-#[macro_use]
-extern crate libfuzzer_sys;
-extern crate your_crate;
+use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     // code to fuzz goes here

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,3 @@
-extern crate cc;
-
 fn main() {
     if let Ok(custom) = ::std::env::var("CUSTOM_LIBFUZZER_PATH") {
         let custom_lib_path = ::std::path::PathBuf::from(&custom);

--- a/example/Cargo.toml
+++ b/example/Cargo.toml
@@ -2,6 +2,7 @@
 name = "example"
 version = "0.1.0"
 authors = ["Simonas Kazlauskas <git@kazlauskas.me>"]
+edition = "2018"
 
 [workspace]
 members = ["."]

--- a/example/src/main.rs
+++ b/example/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: &[u8]| {
     if data == b"banana!" {

--- a/example_arbitrary/Cargo.toml
+++ b/example_arbitrary/Cargo.toml
@@ -2,6 +2,7 @@
 name = "example"
 version = "0.1.0"
 authors = ["Simonas Kazlauskas <git@kazlauskas.me>"]
+edition = "2018"
 
 [workspace]
 members = ["."]

--- a/example_arbitrary/src/main.rs
+++ b/example_arbitrary/src/main.rs
@@ -1,7 +1,6 @@
 #![no_main]
 
-#[macro_use]
-extern crate libfuzzer_sys;
+use libfuzzer_sys::fuzz_target;
 
 fuzz_target!(|data: u16| {
     if data == 0xba7 { // ba[nana]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,7 +23,7 @@ pub fn initialize(_argc: *const isize, _argv: *const *const *const u8) -> isize 
     // Registers a panic hook that aborts the process before unwinding.
     // It is useful to abort before unwinding so that the fuzzer will then be
     // able to analyse the process stack frames to tell different bugs appart.
-    // 
+    //
     // HACK / FIXME: it would be better to use `-C panic=abort` but it's currently
     // impossible to build code using compiler plugins with this flag.
     // We will be able to remove this code when
@@ -46,8 +46,6 @@ macro_rules! fuzz_target {
         fuzz_target!(|$data| $body);
     };
     (|$data:ident: $dty: ty| $body:block) => {
-        extern crate arbitrary;
-
         #[no_mangle]
         pub extern fn rust_fuzzer_test_input(bytes: &[u8]) {
             use arbitrary::{Arbitrary, RingBuffer};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -50,13 +50,16 @@ macro_rules! fuzz_target {
         pub extern fn rust_fuzzer_test_input(bytes: &[u8]) {
             use arbitrary::{Arbitrary, RingBuffer};
 
-            let $data: $dty = if let Ok(d) = RingBuffer::new(bytes, bytes.len()).and_then(|mut b|{
-                Arbitrary::arbitrary(&mut b).map_err(|_| "")
-            }) {
-                d
-            } else {
-                return
+            let mut buf = match RingBuffer::new(bytes, bytes.len()) {
+                Ok(b) => b,
+                Err(_) => return,
             };
+
+            let $data: $dty = match Arbitrary::arbitrary(&mut buf) {
+                Ok(d) => d,
+                Err(_) => return,
+            };
+
             $body
         }
     };


### PR DESCRIPTION
Also update to 2018 edition.

Fixes #42 