### PR TITLE
Run default panic hook before aborting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,7 +28,9 @@ pub fn initialize(_argc: *const isize, _argv: *const *const *const u8) -> isize 
     // impossible to build code using compiler plugins with this flag.
     // We will be able to remove this code when
     // https://github.com/rust-lang/cargo/issues/5423 is fixed.
-    ::std::panic::set_hook(Box::new(|_| {
+    let default_hook = ::std::panic::take_hook();
+    ::std::panic::set_hook(Box::new(move |panic_info| {
+            default_hook(panic_info);
             ::std::process::abort();
     }));
     0


### PR DESCRIPTION
Resolves #36.

The default hook prints the error message, and optionally the backtrace if RUST_BACKTRACE=1 is set, before aborting. This information is very useful to understand the panic and fix the code. While this information was already printed on mac OS before this PR, the information was not present on linux. The information printed now looks like: 

```
thread '<unnamed>' panicked at 'called `Result::unwrap()` on an `Err` value: BufferTooShort', src/libcore/result.rs:1165:5
stack backtrace:
   0: backtrace::backtrace::libunwind::trace
             at /Users/vsts/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.37/src/backtrace/libunwind.rs:88
   1: backtrace::backtrace::trace_unsynchronized
             at /Users/vsts/.cargo/registry/src/github.com-1ecc6299db9ec823/backtrace-0.3.37/src/backtrace/mod.rs:66
   2: std::sys_common::backtrace::_print_fmt
             at src/libstd/sys_common/backtrace.rs:76
   3: <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt
             at src/libstd/sys_common/backtrace.rs:60
   4: core::fmt::write
             at src/libcore/fmt/mod.rs:1028
   5: std::io::Write::write_fmt
             at src/libstd/io/mod.rs:1412
   6: std::sys_common::backtrace::_print
             at src/libstd/sys_common/backtrace.rs:64
   7: std::sys_common::backtrace::print
             at src/libstd/sys_common/backtrace.rs:49
   8: std::panicking::default_hook::{{closure}}
             at src/libstd/panicking.rs:196
   9: std::panicking::default_hook
             at src/libstd/panicking.rs:210
  10: libfuzzer_sys::initialize::{{closure}}
             at ./libfuzzer-sys/src/lib.rs:33
  11: std::panicking::rust_panic_with_hook
             at src/libstd/panicking.rs:477
  12: std::panicking::continue_panic_fmt
             at src/libstd/panicking.rs:380
  13: rust_begin_unwind
             at src/libstd/panicking.rs:307
  14: std::panicking::begin_panic
  15: std::panicking::begin_panic
  16: core::result::Result<T,E>::unwrap
             at /rustc/032a53a06ce293571e51bbe621a5c480e8a28e95/src/libcore/result.rs:933
  17: rust_fuzzer_test_input
             at src/qpack_decode.rs:21
  18: std::panicking::try::do_call
             at /rustc/032a53a06ce293571e51bbe621a5c480e8a28e95/src/libstd/panicking.rs:292
  19: __rust_maybe_catch_panic
             at src/libpanic_unwind/lib.rs:80
  20: std::panicking::try
             at /rustc/032a53a06ce293571e51bbe621a5c480e8a28e95/src/libstd/panicking.rs:271
  21: LLVMFuzzerTestOneInput
             at ./libfuzzer-sys/src/lib.rs:9
  22: _ZN6fuzzer11InputCorpus10PrintStatsEv
  23: _ZN6fuzzer11InputCorpus10PrintStatsEv
  24: _ZN6fuzzer11InputCorpus7ReplaceEPNS_9InputInfoERKNSt3__16vectorIhNS_16fuzzer_allocatorIhEEEE
  25: _ZN6fuzzer11InputCorpus7ReplaceEPNS_9InputInfoERKNSt3__16vectorIhNS_16fuzzer_allocatorIhEEEE
  26: _ZN6fuzzer12FuzzerDriverEPiPPPcPFiPKhmE
             at libfuzzer/FuzzerDriver.cpp:825
  27: main
             at libfuzzer/FuzzerMain.cpp:19
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```

**Environment**
cargo-fuzz 0.5.5
cargo 1.41.0-nightly (8280633db 2019-11-11)
rustc 1.41.0-nightly (3e525e3f6 2019-11-18)
Debian bullseye container running on Mac OS 10.15.1 and Docker Desktop 2.1.0.5