### PR TITLE
Include Debug-formatted output in fuzzer output

### DIFF
--- a/libfuzzer/FuzzerExtFunctions.def
+++ b/libfuzzer/FuzzerExtFunctions.def
@@ -18,6 +18,9 @@ EXT_FUNC(LLVMFuzzerInitialize, int, (int *argc, char ***argv), false);
 EXT_FUNC(LLVMFuzzerCustomMutator, size_t,
          (uint8_t * Data, size_t Size, size_t MaxSize, unsigned int Seed),
          false);
+EXT_FUNC(LLVMFuzzerCustomOutput, void,
+         (const uint8_t * Data, size_t Size),
+         false);
 EXT_FUNC(LLVMFuzzerCustomCrossOver, size_t,
          (const uint8_t * Data1, size_t Size1,
           const uint8_t * Data2, size_t Size2,

--- a/libfuzzer/FuzzerInterface.h
+++ b/libfuzzer/FuzzerInterface.h
@@ -63,6 +63,11 @@ LLVMFuzzerCustomCrossOver(const uint8_t *Data1, size_t Size1,
                           const uint8_t *Data2, size_t Size2, uint8_t *Out,
                           size_t MaxOutSize, unsigned int Seed);
 
+
+// Optional user-provided custom output function.
+FUZZER_INTERFACE_VISIBILITY void
+LLVMFuzzerCustomOutput(const uint8_t *Data, size_t Size);
+
 // Experimental, may go away in future.
 // libFuzzer-provided function to be used inside LLVMFuzzerCustomMutator.
 // Mutates raw data in [Data, Data+Size) inplace.

--- a/libfuzzer/FuzzerLoop.cpp
+++ b/libfuzzer/FuzzerLoop.cpp
@@ -183,6 +183,9 @@ void Fuzzer::DumpCurrentUnit(const char *Prefix) {
     PrintHexArray(CurrentUnitData, UnitSize, "\n");
     PrintASCII(CurrentUnitData, UnitSize, "\n");
   }
+  if (EF->LLVMFuzzerCustomOutput) {
+    EF->LLVMFuzzerCustomOutput(CurrentUnitData, CurrentUnitSize);
+  }
   WriteUnitToFileWithPrefix({CurrentUnitData, CurrentUnitData + UnitSize},
                             Prefix);
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -143,5 +143,25 @@ macro_rules! fuzz_target {
 
             $body
         }
+
+
+        #[export_name = "LLVMFuzzerCustomOutput"]
+        pub extern "C" fn output(ptr: *const u8, len: usize) {
+            use libfuzzer_sys::arbitrary::{Arbitrary, RingBuffer};
+
+            let bytes = unsafe { std::slice::from_raw_parts(ptr, len) };
+
+            let mut buf = match RingBuffer::new(bytes, bytes.len()) {
+                Ok(b) => b,
+                Err(_) => return,
+            };
+
+            let data: $dty = match Arbitrary::arbitrary(&mut buf) {
+                Ok(d) => d,
+                Err(_) => return,
+            };
+
+            println!("Formatted: {:?}", data);
+        }
     };
 }


### PR DESCRIPTION
Fixes https://github.com/rust-fuzz/libfuzzer-sys/issues/47

This is really a proof of concept. Ideally we can upstream LLVMFuzzerCustomOutput, and also we can make this work so that it is able to turn itself off for types that don't implement Debug.

Thoughts? @nagisa @fitzgen