### PR TITLE
Reexport arbitrary crate

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+pub use arbitrary;
+
 extern "C" {
     #![allow(improper_ctypes)] // we do not actually cross the FFI bound here
 
@@ -48,7 +50,7 @@ macro_rules! fuzz_target {
     (|$data:ident: $dty: ty| $body:block) => {
         #[no_mangle]
         pub extern fn rust_fuzzer_test_input(bytes: &[u8]) {
-            use arbitrary::{Arbitrary, RingBuffer};
+            use libfuzzer_sys::arbitrary::{Arbitrary, RingBuffer};
 
             let mut buf = match RingBuffer::new(bytes, bytes.len()) {
                 Ok(b) => b,


### PR DESCRIPTION
Currently `cargo fuzz` fails because it can't find `arbitrary` (caused by https://github.com/rust-fuzz/libfuzzer-sys/pull/43). We should either do this or tweak `cargo fuzz init` to add an explicit dependency on `arbitrary`

r? @fitzgen